### PR TITLE
lsof hang fix

### DIFF
--- a/network/NetworkConnections.swift
+++ b/network/NetworkConnections.swift
@@ -19,7 +19,7 @@ class NetworkConnections: NetworkModule {
     }
     
     func captureNetworkConnections(writeFile: URL) {
-        let command = "lsof -i"
+        let command = "lsof -i -n"
         let output = Aftermath.shell("\(command)")
         
         self.addTextToFile(atUrl: writeFile, text: output)


### PR DESCRIPTION
- add -n to fail fast if host is isolated which causes lsof -i to hang