### PR TITLE
added slack to personal info disable

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ To uninstall the aftermath binary, run the `AftermathUninstaller.pkg` from the [
     WARNING: This will be a time-intensive, memory-consuming scan.
 --disable -> disable a set of aftermath features that may collect personal user data
     Available features to disable: browsers -> collecting browser information | browser-killswitch -> force-closes browers | -> databases -> tcc & lsquarantine databases | filesystem -> walking the filesystem for timestamps | proc-info -> collecting process information via TrueTree and eslogger | all -> all aforementioned options 
-    usage: --disable browsers browser-killswitch databases filesystem proc-info
+    usage: --disable browsers browser-killswitch databases filesystem proc-info slack
            --disable all
 --es-logs -> specify which Endpoint Security events (space-separated) to collect (defaults are: create exec mmap). To disable, see --disable es-logs
     usage: --es-logs setuid unmount write

--- a/aftermath/Command.swift
+++ b/aftermath/Command.swift
@@ -29,7 +29,7 @@ class Command {
     static var unifiedLogsFile: String? = nil
     static var esLogs: [String] = ["create", "exec", "mmap"]
     static let version: String = "2.1.0"
-    static var disableFeatures: [String:Bool] = ["all":false, "browsers":false, "browser-killswitch":false, "databases":false, "filesystem":false, "proc-info":false]
+    static var disableFeatures: [String:Bool] = ["all": false, "browsers": false, "browser-killswitch": false, "databases": false, "filesystem": false, "proc-info": false, "slack": false]
     
     static func main() {
         setup(with: CommandLine.arguments)
@@ -264,7 +264,7 @@ class Command {
          print("    usage: --collect-dirs /Users/<USER>/Downloads /tmp")
          print("--deep -> performs deep scan and captures metadata from Users entire directory (WARNING: this may be time-consuming)")
          print("--disable -> disable a set of aftermath features that may collect personal user data")
-         print("    usage: --disable browsers browser-killswitch databases filesystem proc-info")
+         print("    usage: --disable browsers browser-killswitch databases filesystem proc-info slack")
          print("           --disable all")
          print("--es-logs -> specify which Endpoint Security events (space-separated) to collect (defaults are: create exec mmap)")
          print("    usage: --es-logs exec open rename")

--- a/filesystem/Slack.swift
+++ b/filesystem/Slack.swift
@@ -35,7 +35,12 @@ class Slack: FileSystemModule {
     }
     
     override func run() {
-        self.log("Collecting Slack information")
-        extractSlackPrefs()
+        if Command.disableFeatures["slack"] == false {
+            self.log("Collecting Slack information")
+            extractSlackPrefs()
+        } else {
+            self.log("Skipping capturing Slack preferences")
+        }
+        
     }
 }


### PR DESCRIPTION
- users can now add `--disable slack` to not collect any slack preferences
- this will also assist in not receiving a TCC prompt for slack's sandboxed environment 